### PR TITLE
feat: Support auth headers in webhook delivery

### DIFF
--- a/worker/src/routes/agents.ts
+++ b/worker/src/routes/agents.ts
@@ -26,6 +26,8 @@ export async function handlePostAgent(
     signingKey?: string;
     capabilities?: string[];
     webhookUrl?: string;
+    webhookToken?: string;
+    webhookSecret?: string;
   };
 
   try {
@@ -65,6 +67,8 @@ export async function handlePostAgent(
     signingKey: body.signingKey,
     capabilities: body.capabilities,
     webhookUrl: body.webhookUrl,
+    webhookToken: body.webhookToken,
+    webhookSecret: body.webhookSecret,
     apiKeyHash,
     lastSeen: new Date().toISOString(),
     createdAt: new Date().toISOString(),
@@ -113,6 +117,8 @@ export async function handlePatchAgent(
 
   let body: {
     webhookUrl?: string | null;
+    webhookToken?: string | null;
+    webhookSecret?: string | null;
     capabilities?: string[];
     publicKey?: string;
     signingKey?: string;
@@ -132,6 +138,12 @@ export async function handlePatchAgent(
   // Update allowed fields
   if (body.webhookUrl !== undefined) {
     record.webhookUrl = body.webhookUrl === null ? undefined : body.webhookUrl;
+  }
+  if (body.webhookToken !== undefined) {
+    record.webhookToken = body.webhookToken === null ? undefined : body.webhookToken;
+  }
+  if (body.webhookSecret !== undefined) {
+    record.webhookSecret = body.webhookSecret === null ? undefined : body.webhookSecret;
   }
   if (body.capabilities !== undefined) {
     record.capabilities = body.capabilities;

--- a/worker/src/routes/messages.ts
+++ b/worker/src/routes/messages.ts
@@ -190,19 +190,30 @@ export async function handlePostMessage(
       );
     }
 
-    // Webhook delivery (fire-and-forget, no retry).
+    // Webhook delivery (fire-and-forget with error logging).
     // Messages persist in KV regardless of webhook success — agents
     // should poll as fallback if webhook delivery is unreliable.
     const recipientRaw = await env.AGENTS.get(`agent:${recipient}`);
     if (recipientRaw) {
       const recipientAgent: AgentRecord = JSON.parse(recipientRaw);
       if (recipientAgent.webhookUrl) {
+        const webhookHeaders: Record<string, string> = {
+          'Content-Type': 'application/json',
+        };
+        if (recipientAgent.webhookToken) {
+          webhookHeaders['Authorization'] = `Bearer ${recipientAgent.webhookToken}`;
+        }
+        if (recipientAgent.webhookSecret) {
+          webhookHeaders['X-Webhook-Secret'] = recipientAgent.webhookSecret;
+        }
         ctx.waitUntil(
           fetch(recipientAgent.webhookUrl, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: webhookHeaders,
             body: JSON.stringify(msgEnvelope),
-          }).catch(() => {}) // silently ignore webhook failures
+          }).catch((err) => {
+            console.error(`Webhook delivery failed for ${recipient}: ${err.message}`);
+          })
         );
       }
     }

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -12,6 +12,8 @@ export interface AgentRecord {
   signingKey: string;
   capabilities?: string[];
   webhookUrl?: string;
+  webhookToken?: string;
+  webhookSecret?: string;
   apiKeyHash: string;
   lastSeen: string;
   createdAt: string;


### PR DESCRIPTION
## Problem
ClaWTalk webhook delivery sends no authentication headers. Agents using gateways that require auth (like OpenClaw's hooks endpoint) can't receive webhooks — the fetch silently fails.

## Solution
- Added `webhookToken` and `webhookSecret` fields to `AgentRecord`
- `PATCH /agents/:name` and registration now accept these fields
- Webhook dispatch includes `Authorization: Bearer <token>` if `webhookToken` is set
- Webhook dispatch includes `X-Webhook-Secret` if `webhookSecret` is set
- Improved error logging (was `.catch(() => {})`, now logs the error)

## Usage
```bash
curl -X PATCH /agents/MyAgent \\
  -H 'Authorization: Bearer ct_...' \\
  -d '{"webhookUrl": "https://my-gateway/hooks/clawtalk", "webhookToken": "my-secret-token"}'
```

Backward compatible — agents without these fields work exactly as before.