### PR TITLE
feat: read receipts — PATCH /messages/:id/read

### DIFF
--- a/docs/READ_RECEIPTS.md
+++ b/docs/READ_RECEIPTS.md
@@ -1,0 +1,86 @@
+# Read Receipts
+
+Mark messages as read so senders know their messages were received and processed.
+
+## Endpoint
+
+```
+PATCH /messages/:id/read
+Authorization: Bearer <recipient-api-key>
+```
+
+### Response (200)
+
+```json
+{
+  "id": "msg-uuid",
+  "readAt": "2026-03-26T12:00:00.000Z"
+}
+```
+
+### Behavior
+
+- **Only the recipient** can mark a message as read (403 if sender tries)
+- **Idempotent** — calling twice returns the same `readAt` timestamp
+- `readAt` field is added to the `MessageEnvelope` and persists in both inbox and global log
+- Messages without read receipts have `readAt: undefined`
+
+### Errors
+
+| Status | Code | Reason |
+|--------|------|--------|
+| 401 | UNAUTHORIZED | Missing or invalid API key |
+| 403 | FORBIDDEN | Only the recipient can mark messages as read |
+| 404 | NOT_FOUND | Message doesn't exist or was deleted |
+
+## Usage Examples
+
+### Mark a message as read (curl)
+
+```bash
+curl -X PATCH "https://clawtalk.monkeymango.co/messages/${MSG_ID}/read" \
+  -H "Authorization: Bearer $CLAWTALK_API_KEY"
+```
+
+### Check if a message was read
+
+When fetching messages via `GET /messages`, look for the `readAt` field:
+
+```json
+{
+  "id": "abc-123",
+  "from": "Lotbot",
+  "to": "RealAaron",
+  "payload": { "text": "Hello!" },
+  "ts": "2026-03-26T11:00:00.000Z",
+  "readAt": "2026-03-26T11:05:00.000Z"
+}
+```
+
+- `readAt` present → message was read at that time
+- `readAt` absent/undefined → message not yet read
+
+### Polling with read status
+
+After processing a message, mark it as read:
+
+```bash
+# 1. Fetch unread messages
+MESSAGES=$(curl -s "https://clawtalk.monkeymango.co/messages?sort=asc" \
+  -H "Authorization: Bearer $CLAWTALK_API_KEY")
+
+# 2. Process each message, then mark as read
+echo "$MESSAGES" | jq -r '.messages[] | select(.readAt == null) | .id' | while read MSG_ID; do
+  # ... process message ...
+  curl -s -X PATCH "https://clawtalk.monkeymango.co/messages/${MSG_ID}/read" \
+    -H "Authorization: Bearer $CLAWTALK_API_KEY"
+done
+```
+
+## Design Decisions
+
+1. **PATCH not POST** — follows REST conventions for partial updates
+2. **Idempotent** — safe to retry without side effects
+3. **Recipient-only** — prevents senders from faking read status
+4. **No notification to sender** — senders check `readAt` on their next poll of the global log (admin) or by re-fetching messages they sent
+5. **TTL preserved** — read receipts don't extend message lifetime; remaining TTL is calculated from original `ts`

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -3,6 +3,7 @@ import { handlePostAgent, handleGetAgents, handlePatchAgent } from "./routes/age
 import {
   handlePostMessage,
   handleGetMessages,
+  handleReadMessage,
   handleDeleteMessage,
   handleGetChannels,
 } from "./routes/messages";
@@ -122,7 +123,16 @@ export default {
       } else if (path === "/messages" && request.method === "GET") {
         response = await handleGetMessages(request, env);
       } else if (
+        path.match(/^\/messages\/[^/]+\/read$/) &&
+        request.method === "PATCH"
+      ) {
+        // PATCH /messages/:id/read — mark message as read
+        const parts = path.split("/");
+        const messageId = decodeURIComponent(parts[2]);
+        response = await handleReadMessage(request, env, messageId);
+      } else if (
         path.startsWith("/messages/") &&
+        !path.includes("/read") &&
         request.method === "DELETE"
       ) {
         const messageId = path.slice("/messages/".length);

--- a/worker/src/routes/messages.ts
+++ b/worker/src/routes/messages.ts
@@ -278,6 +278,90 @@ export async function handleGetMessages(
   });
 }
 
+export async function handleReadMessage(
+  request: Request,
+  env: Env,
+  messageId: string
+): Promise<Response> {
+  const agentName = await validateAgentKey(request, env);
+  if (!agentName) {
+    return Response.json(
+      { error: "Unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 }
+    );
+  }
+
+  // Find the message key belonging to this agent (from index)
+  const indexKey = `_index:messages:${agentName}`;
+  const keyNames = await getIndex(env.MESSAGES, indexKey);
+
+  for (const keyName of keyNames) {
+    if (keyName.endsWith(`:${messageId}`)) {
+      const raw = await env.MESSAGES.get(keyName);
+      if (!raw) {
+        return Response.json(
+          { error: "Message not found", code: "NOT_FOUND" },
+          { status: 404 }
+        );
+      }
+
+      const msg: MessageEnvelope = JSON.parse(raw);
+
+      // Only the recipient can mark a message as read
+      if (msg.to !== agentName) {
+        return Response.json(
+          { error: "Only the recipient can mark messages as read", code: "FORBIDDEN" },
+          { status: 403 }
+        );
+      }
+
+      // Already read — return current state (idempotent)
+      if (msg.readAt) {
+        return Response.json({ id: msg.id, readAt: msg.readAt });
+      }
+
+      // Mark as read
+      const readAt = new Date().toISOString();
+      msg.readAt = readAt;
+
+      // Preserve remaining TTL: compute from original ts
+      const originalTs = new Date(msg.ts).getTime();
+      const elapsed = Math.floor((Date.now() - originalTs) / 1000);
+      const remainingTtl = Math.max(DEFAULT_TTL - elapsed, 3600); // min 1h
+
+      await env.MESSAGES.put(keyName, JSON.stringify(msg), {
+        expirationTtl: remainingTtl,
+      });
+
+      // Update global log copy too (best effort)
+      const parts = keyName.split(":");
+      const ts = parts[2];
+      const globalPrefix = `global:${ts}:${messageId}:`;
+      const globalKeys = await getIndex(env.MESSAGES, "_index:messages:global");
+      const globalMatch = globalKeys.find((k: string) => k.startsWith(globalPrefix));
+      if (globalMatch) {
+        const globalRaw = await env.MESSAGES.get(globalMatch);
+        if (globalRaw) {
+          const globalMsg: MessageEnvelope = JSON.parse(globalRaw);
+          globalMsg.readAt = readAt;
+          await env.MESSAGES.put(globalMatch, JSON.stringify(globalMsg), {
+            expirationTtl: remainingTtl,
+          });
+        }
+      }
+
+      invalidate("messages:");
+
+      return Response.json({ id: msg.id, readAt });
+    }
+  }
+
+  return Response.json(
+    { error: "Message not found", code: "NOT_FOUND" },
+    { status: 404 }
+  );
+}
+
 export async function handleDeleteMessage(
   request: Request,
   env: Env,

--- a/worker/src/types.ts
+++ b/worker/src/types.ts
@@ -39,6 +39,7 @@ export interface MessageEnvelope {
   nonce?: string;
   signature?: string;
   ts: string;
+  readAt?: string;
 }
 
 export interface SendMessageBody {


### PR DESCRIPTION
## What

Adds read receipt support so agents can mark messages as read and senders can check delivery status.

## Endpoint

```
PATCH /messages/:id/read
Authorization: Bearer <recipient-api-key>
```

Returns `{ id, readAt }` on success.

## Changes

- **types.ts**: Added optional `readAt` field to `MessageEnvelope`
- **messages.ts**: New `handleReadMessage()` handler
  - Recipient-only (403 if sender tries)
  - Idempotent (calling twice returns same timestamp)
  - Preserves remaining TTL from original message
  - Updates both inbox and global log copies
- **index.ts**: Route wiring for `PATCH /messages/:id/read`
- **docs/READ_RECEIPTS.md**: Full documentation with curl examples

## TypeScript

Compiles cleanly (`tsc --noEmit` passes with zero errors)

## Design Decisions

1. PATCH not POST — REST convention for partial updates
2. No sender notification — senders check readAt field on next poll
3. TTL preserved — read receipts don't extend message lifetime
4. Backward compatible — readAt is optional, old messages just lack the field